### PR TITLE
Update EFCacheKeyProvider.cs

### DIFF
--- a/src/EFSecondLevelCache.Core/EFCacheKeyProvider.cs
+++ b/src/EFSecondLevelCache.Core/EFCacheKeyProvider.cs
@@ -32,7 +32,7 @@ namespace EFSecondLevelCache.Core
         public EFCacheKey GetEFCacheKey<T>(IQueryable<T> query, Expression expression, string saltKey = "")
         {
             var expressionVisitorResult = EFQueryExpressionVisitor.GetDebugView(expression);
-            var sql = query.ToSql();
+            var sql = query.Expression.ToString();
             var key = $"{sql}{Environment.NewLine}{expressionVisitorResult.DebugView}{Environment.NewLine}{saltKey}";
             var keyHash = _cacheKeyHashProvider.ComputeHash(key);
             return new EFCacheKey


### PR DESCRIPTION
I think using `query.Expression.ToString()`  is way faster than `query.ToSql`. Especial when it comes to high rate of using the cache. All my tests showing the same result and working perfecly.